### PR TITLE
Replace Zentrick references with DoubleVerify

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/InteractiveAdvertisingBureau/VAST-Tester.svg?style=shield)](https://circleci.com/gh/InteractiveAdvertisingBureau/VAST-Tester) [![JavaScript Standard Style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](https://standardjs.com/)
 
-Tests IAB VAST ads. Contributed by the [Zentrick](https://www.zentrick.com/) team.
+Tests IAB VAST ads. Contributed by the [DoubleVerify](https://www.doubleverify.com/) team.
 
 ## Getting Started
 

--- a/src/main/components/About.js
+++ b/src/main/components/About.js
@@ -26,11 +26,11 @@ const About = () => (
       <div>
         by the{' '}
         <a
-          href='https://www.zentrick.com/'
+          href='https://www.doubleverify.com/'
           target='_blank'
           rel='noopener noreferrer'
         >
-          Zentrick
+          DoubleVerify
         </a>{' '}
         team
       </div>


### PR DESCRIPTION
Zentrick was acquired by DoubleVerify. It would make sense to update the acknowledgments. I assume that's okay?